### PR TITLE
Fix Lenis smooth scroll styles

### DIFF
--- a/src/app/admin/categories/page.js
+++ b/src/app/admin/categories/page.js
@@ -19,7 +19,6 @@ export default function AdminCategoriesPage() {
     (async () => {
       try {
         const res = await adminApiService.categories.getAll();
-        console.log("Fetched categories:", res.data);
 
         // Assume res.data is an array of category objects, each with at least:
         // { _id, name, parent (or parentId), ... }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,7 +73,7 @@
 html {
   box-sizing: border-box;
   font-size: 62.5%;
-  scroll-behavior: smooth;
+  scroll-behavior: auto;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -111,4 +111,26 @@ body {
 
 .scrolling-text:active {
   cursor: grabbing;
+}
+
+/* Lenis smooth scroll styles */
+html.lenis,
+html.lenis body {
+  height: auto;
+}
+
+.lenis.lenis-smooth {
+  scroll-behavior: auto !important;
+}
+
+.lenis.lenis-smooth [data-lenis-prevent] {
+  overscroll-behavior: contain;
+}
+
+.lenis.lenis-stopped {
+  overflow: hidden;
+}
+
+.lenis.lenis-scrolling iframe {
+  pointer-events: none;
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -8,7 +8,7 @@ export const metadata = {};
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en" className="scroll-smooth">
+    <html lang="en">
       <body>
         <Header />
         <SmoothScrollProvider>{children}</SmoothScrollProvider>

--- a/src/components/categories/CategoryCarousel.js
+++ b/src/components/categories/CategoryCarousel.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence, useAnimation } from "framer-motion";
 import Link from "next/link";
 import Image from "next/image";
@@ -14,12 +14,12 @@ export default function CategoryCarousel({ slides }) {
   const timeoutRef = useRef(null);
   const imageControls = useAnimation();
 
-  const resetTimer = () => {
+  const resetTimer = useCallback(() => {
     clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => {
       setIndex((prev) => (prev + 1) % slides.length);
     }, SLIDE_INTERVAL);
-  };
+  }, [slides.length]);
 
   useEffect(() => {
     resetTimer();
@@ -32,7 +32,7 @@ export default function CategoryCarousel({ slides }) {
       },
     });
     return () => clearTimeout(timeoutRef.current);
-  }, [index, imageControls]);
+  }, [index, imageControls, resetTimer]);
 
   const goToSlide = (i) => {
     setIndex(i);

--- a/src/components/categories/CategoryMegaMenu/CategoryTile.js
+++ b/src/components/categories/CategoryMegaMenu/CategoryTile.js
@@ -9,8 +9,6 @@ export default function CategoryTile({
   onHover,
   labelSize = "text-base",
 }) {
-  console.log("Rendering CategoryTile for:", category.image);
-
   return (
     <Link
       href={`/categories/${category.slug}`}

--- a/src/components/header/HeaderCartContent.js
+++ b/src/components/header/HeaderCartContent.js
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
+
+// Lazy load the heavy lottie player only on the client
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((m) => m.Player),
+  { ssr: false }
+);
 import Image from "next/image";
 import useCartStore from "@/store/cartStore";
 

--- a/src/components/header/HeaderSearchIcon.js
+++ b/src/components/header/HeaderSearchIcon.js
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
+
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((m) => m.Player),
+  { ssr: false }
+);
 import Image from "next/image";
 
 export default function HeaderSearchIcon() {

--- a/src/components/products/CategoryProductsContent.js
+++ b/src/components/products/CategoryProductsContent.js
@@ -37,7 +37,6 @@ export default function CategoryProductsContent() {
           ...obj,
           category: slug,
         });
-        console.log("Fetched products:", res);
 
         setProducts(res.data.products || []);
         setTotal(res.meta?.pages || 1); // meta.pages from backend

--- a/src/components/products/RecentlyViewed.js
+++ b/src/components/products/RecentlyViewed.js
@@ -21,8 +21,6 @@ export default function RecentlyViewed() {
 
       try {
         const res = await apiService.products.getByIds(productIds);
-        console.log("Fetched recently viewed products:", res);
-
         setProducts(res || []);
       } catch (err) {
         console.error("Failed to fetch recently viewed products", err);

--- a/src/components/products/SaleBadge.js
+++ b/src/components/products/SaleBadge.js
@@ -1,4 +1,10 @@
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
+
+// Lazy load Player to avoid large bundle size
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((m) => m.Player),
+  { ssr: false }
+);
 
 export default function SaleBadge({ discountPercent }) {
   return (

--- a/src/components/user/ProfileTile.js
+++ b/src/components/user/ProfileTile.js
@@ -2,7 +2,12 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
+
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((m) => m.Player),
+  { ssr: false }
+);
 
 export default function ProfileTile({ href, src, title, description }) {
   return (

--- a/src/lib/apiService.js
+++ b/src/lib/apiService.js
@@ -65,7 +65,6 @@ const apiService = {
       return api.put(`/api/cart/${id}`, item);
     },
     clear: () => {
-      console.log("[apiService.cart.clear] Called");
       return api.delete("/api/cart/clear");
     },
   },


### PR DESCRIPTION
## Summary
- remove `scroll-smooth` class from html element
- set global `scroll-behavior` to `auto`
- add missing Lenis CSS helpers so wheel events work on every OS
- lazily load lottie player components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413e8f522c832b942bb6b15dc37b59